### PR TITLE
feat: :bug: Change of version of artifacts from v3 to v4 in the CI be…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload coverage report
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage


### PR DESCRIPTION
Change of version of artifacts from v3 to v4 in the CI because v3 is deprecated

# Description

Change of version of artifacts from v3 to v4 in the CI because v3 is deprecated

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ¿Have you done unit tests?

- [x] Sí
- [ ] No

# Checklist summary of changes:

- [x] Change of version of artifacts from v3 to v4 in the CI because v3 is deprecated

Co-authored-by: Ruben JC
