### PR TITLE
ci: :wrench: The configuration was made so that the CI fails with les…

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,5 +14,13 @@ const config = {
   collectCoverage: true, // Habilita la recolección de cobertura
   coverageDirectory: 'coverage', // Directorio donde se guardará el informe de cobertura
   coverageReporters: ['json', 'lcov', 'text', 'clover'], // Tipos de informes de cobertura a generar
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };
 module.exports = config;


### PR DESCRIPTION
The configuration was made so that the CI fails with less than 80% coverage in unit tests

# Description

The configuration was made so that the CI fails with less than 80% coverage in unit tests

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ¿Have you done unit tests?

- [x] Sí
- [ ] No

# Checklist summary of changes:

- [x] The configuration was made so that the CI fails with less than 80% coverage in unit tests
